### PR TITLE
[SASP-3014] JarJar should not mangle non-modified jars

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ ThisBuild / organizationName := "eed3si9n"
 ThisBuild / organizationHomepage := Some(url("http://eed3si9n.com/"))
 ThisBuild / version := {
   val old = (ThisBuild / version).value
-  if ((ThisBuild / isSnapshot).value) "1.9.0-SNAPSHOT"
+  if ((ThisBuild / isSnapshot).value) "1.9.0-db-SNAPSHOT"
   else old
 }
 ThisBuild / description := "utility to shade Scala libraries"

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/MainProcessor.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/MainProcessor.java
@@ -130,7 +130,9 @@ class MainProcessor implements JarProcessor
         }
 
         if (!pr.modified) {
-            struct.assign(origStruct);
+            // copy only data field.
+            // Specifically, don't copy name for the sake of Misplaced class processors.
+            struct.data = origStruct.data;
         }
 
         if (!origStruct.name.equals(struct.name)) {

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/PackageRemapper.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/PackageRemapper.java
@@ -34,6 +34,8 @@ class PackageRemapper extends Remapper
     private final Map<Object, String> valueCache = new HashMap<Object, String>();
     private final boolean verbose;
 
+    protected boolean modified = false;
+
     public PackageRemapper(List<Rule> ruleList, boolean verbose) {
         this.verbose = verbose;
         wildcards = PatternElement.createWildcards(ruleList);
@@ -130,8 +132,11 @@ class PackageRemapper extends Remapper
     private String replaceHelper(String value) {
         for (Wildcard wildcard : wildcards) {
             String test = wildcard.replace(value);
-            if (test != null)
+            if (test != null) {
+                if (test != value)
+                    this.modified = true;
                 return test;
+            }
         }
         return value;
     }

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/util/EntryStruct.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/util/EntryStruct.java
@@ -24,14 +24,10 @@ public class EntryStruct {
 
     public EntryStruct copy() {
         EntryStruct result = new EntryStruct();
-        result.assign(this);
-        return result;
-    }
-
-    public void assign(EntryStruct other) {
         data = other.data;
         name = other.name;
         time = other.time;
         skipTransform = other.skipTransform;
+        return result;
     }
 }

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/util/EntryStruct.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/util/EntryStruct.java
@@ -21,4 +21,17 @@ public class EntryStruct {
     public String name;
     public long time;
     public boolean skipTransform;
+
+    public EntryStruct copy() {
+        EntryStruct result = new EntryStruct();
+        result.assign(this);
+        return result;
+    }
+
+    public void assign(EntryStruct other) {
+        data = other.data;
+        name = other.name;
+        time = other.time;
+        skipTransform = other.skipTransform;
+    }
 }

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/util/EntryStruct.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/util/EntryStruct.java
@@ -24,10 +24,10 @@ public class EntryStruct {
 
     public EntryStruct copy() {
         EntryStruct result = new EntryStruct();
-        data = other.data;
-        name = other.name;
-        time = other.time;
-        skipTransform = other.skipTransform;
+        result.data = data;
+        result.name = name;
+        result.time = time;
+        result.skipTransform = skipTransform;
         return result;
     }
 }

--- a/jarjar/src/test/java/com/eed3si9n/jarjar/MethodRewriterTest.java
+++ b/jarjar/src/test/java/com/eed3si9n/jarjar/MethodRewriterTest.java
@@ -46,7 +46,7 @@ public class MethodRewriterTest extends TestCase {
     }
   }
 
-  private static byte[] readInputStream(InputStream inputStream) throws IOException {
+  static byte[] readInputStream(InputStream inputStream) throws IOException {
     byte[] buf = new byte[0x2000];
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     IoUtil.pipe(inputStream, baos, buf);

--- a/jarjar/src/test/java/com/eed3si9n/jarjar/UnmodifiedTest.java
+++ b/jarjar/src/test/java/com/eed3si9n/jarjar/UnmodifiedTest.java
@@ -1,0 +1,39 @@
+package com.eed3si9n.jarjar;
+
+import com.eed3si9n.jarjar.util.EntryStruct;
+import com.eed3si9n.jarjar.util.RemappingClassTransformer;
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.objectweb.asm.ClassReader;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.eed3si9n.jarjar.MethodRewriterTest.readInputStream;
+
+public class UnmodifiedTest
+        extends TestCase
+{
+    @Test
+    public void testNotModified() throws Exception {
+        Rule rule = new Rule();
+        rule.setPattern("com.abc");
+        rule.setResult("com.def");
+
+        MainProcessor mp = new MainProcessor(List.of(rule), false, false, "move");
+
+        EntryStruct entryStruct = new EntryStruct();
+        entryStruct.name = "BigtableIO$Write.class";
+        entryStruct.skipTransform = false;
+        entryStruct.time = 0;
+        entryStruct.data =
+                readInputStream(
+                        getClass().getResourceAsStream("/com/eed3si9n/jarjar/BigtableIO$Write.class"));
+
+        EntryStruct orig = entryStruct.copy();
+
+        mp.process(entryStruct);
+
+        assertEquals(entryStruct.data, orig.data);
+    }
+}


### PR DESCRIPTION
Modifies jarjar so that it tracks whether the content is modified and if not, the class file is returned unmodified.

Purpose of this is making it easier to deal with class path conflict errors. Before this change, if the shading is applied to certain bazel target, then even if some dependency is not subject to shading rules, it gets mangled in non-compatible way with original library, upsetting classpath checker, when there is no actual problem.

Originally developed in in https://github.com/databricks/universe/pull/464965/commits/1f4b9cc17395746af7beb7313ed0044a5dbd5bc6

Test coverage: unit tests.